### PR TITLE
fix-non-square-puzzles

### DIFF
--- a/src/Nudoku.Engine/Generators/PuzzleGeneratorV1.cs
+++ b/src/Nudoku.Engine/Generators/PuzzleGeneratorV1.cs
@@ -30,7 +30,7 @@ public class PuzzleGeneratorV1 : IPuzzleGenerator
 
     private IGrid GenerateSolvedGrid(int size, int boxWidth, int boxHeight)
     {
-        var emptyGrid = new Grid(boxWidth, boxHeight, new int[size * size]);
+        var emptyGrid = new Grid(size, boxWidth, boxHeight, new int[size * size]);
         var solvedGrid = _solver.FindSolution(emptyGrid);
 
         if (solvedGrid == null)
@@ -55,6 +55,6 @@ public class PuzzleGeneratorV1 : IPuzzleGenerator
             }
         }
 
-        return new Grid(solvedGrid.BoxWidth, solvedGrid.BoxHeight, cells);
+        return new Grid(solvedGrid.Size, solvedGrid.BoxWidth, solvedGrid.BoxHeight, cells);
     }
 }

--- a/src/Nudoku.Engine/Grid.cs
+++ b/src/Nudoku.Engine/Grid.cs
@@ -9,48 +9,54 @@ public record Grid : IGrid
     public int BoxHeight { get; }
     public int[] Cells { get; }
 
-    public Grid(int size, int[] cells)
+    public Grid(int size, int boxWidth, int boxHeight, int[] cells)
+    {
+        if (boxWidth * boxHeight != size)
+            throw new ArgumentException("Box size must match the size of the grid.");
+
+        if (cells.Length != size * size)
+            throw new ArgumentException("Cells array must match the size of the grid.");
+
+        Size = size;
+        BoxWidth = boxWidth;
+        BoxHeight = boxHeight;
+        Cells = (int[])cells.Clone();
+    }
+
+    public static Grid Create(int size, int[] cells)
     {
         if (cells.Length != size * size)
             throw new ArgumentException("Cells array must match the size of the grid.");
 
         var boxSize = (int)Math.Sqrt(size);
         
-        Size = size;
-        BoxWidth = boxSize;
-        BoxHeight = boxSize;
-        Cells = (int[])cells.Clone();
+        return new Grid(size, boxSize, boxSize, cells);
     }
-
-    public Grid(int boxWidth, int boxHeight, int[] cells)
+    
+    public static Grid Create(int boxWidth, int boxHeight, int[] cells)
     {
         var size = boxWidth * boxHeight;
         
-        if (cells.Length != size * size)
-            throw new ArgumentException("Cells array must match the size of the grid.");
-
-        Size = size;
-        BoxWidth = boxWidth;
-        BoxHeight = boxHeight;
-        Cells = (int[])cells.Clone();
-    }
-
-    public Grid(int[,] cells) : this((int)Math.Sqrt(cells.GetLength(0)), (int)Math.Sqrt(cells.GetLength(0)), cells)
-    {
+        return new Grid(size, boxWidth, boxHeight, cells);
     }
     
-    public Grid(int boxWidth, int boxHeight, int[,] cells)
+    public static Grid Create(int[,] cells)
     {
-        if (cells.GetLength(0) != cells.GetLength(1))
-            throw new ArgumentException("Cells array must be square.");
+        var dimension0Length = cells.GetLength(0);
+
+        if (dimension0Length != cells.GetLength(1))
+            throw new ArgumentException("Cells array must be square.", nameof(cells));
         
-        if (boxHeight * boxWidth != cells.GetLength(0))
-            throw new ArgumentException("Box size must match the size of the grid.");
+        var boxSize = (int)Math.Sqrt(dimension0Length);
         
-        Size = cells.GetLength(0);
-        BoxWidth = boxWidth;
-        BoxHeight = boxHeight;
-        Cells = cells.Cast<int>().ToArray();
+        return Create(boxSize, boxSize, cells);
+    }
+    
+    public static Grid Create(int boxWidth, int boxHeight, int[,] cells)
+    {
+        var size = boxWidth * boxHeight;
+        
+        return new Grid(size, boxWidth, boxHeight, cells.Cast<int>().ToArray());
     }
 
     public int GetCell(int index) => Cells[index];
@@ -80,7 +86,7 @@ public record Grid : IGrid
     {
         var newCells = (int[])Cells.Clone();
         newCells[index] = value;
-        return new Grid(BoxWidth, BoxHeight, newCells);
+        return new Grid(Size, BoxWidth, BoxHeight, newCells);
     }
 
     public IGrid WithCell(int column, int row, int value) => WithCell(GetIndex(column, row), value);

--- a/src/Nudoku.Engine/PuzzleExample.cs
+++ b/src/Nudoku.Engine/PuzzleExample.cs
@@ -5,7 +5,7 @@ public class PuzzleExample
     /// <summary>
     /// 9 x 9 puzzle, with 3 x 3 boxes
     /// </summary>
-    public static readonly IGrid Puzzle9X9 = new Grid(new[,]
+    public static readonly IGrid Puzzle9X9 = Grid.Create(new[,]
     {
         { 4, 0, 0, 0, 0, 0, 0, 0, 8 },
         { 8, 7, 0, 0, 0, 0, 0, 5, 6 },
@@ -20,7 +20,7 @@ public class PuzzleExample
         { 0, 2, 0, 3, 0, 5, 0, 1, 0 }
     });
     
-    public static readonly IGrid Solution9X9 = new Grid(new[,]
+    public static readonly IGrid Solution9X9 = Grid.Create(new[,]
     {
         { 4, 3, 1, 5, 2, 6, 7, 9, 8 },
         { 8, 7, 2, 9, 3, 1, 4, 5, 6 },
@@ -36,7 +36,7 @@ public class PuzzleExample
     /// <summary>
     /// Unsolvable 6 x 6 puzzle, with 3 x 2 boxes
     /// </summary>
-    public static readonly IGrid UnsolvablePuzzle6X6 = new Grid(3, 2, new[,]
+    public static readonly IGrid UnsolvablePuzzle6X6 = Grid.Create(3, 2, new[,]
     {
         { 0, 0, 0, 1, 4, 0 },
         { 0, 0, 5, 0, 0, 0 },
@@ -49,7 +49,7 @@ public class PuzzleExample
     /// <summary>
     /// 6 x 6 puzzle, with 3 x 2 boxes
     /// </summary>
-    public static readonly IGrid Puzzle6X6 = new Grid(3, 2, new[,]
+    public static readonly IGrid Puzzle6X6 = Grid.Create(3, 2, new[,]
     {
         { 1, 2, 0, 4, 5, 0},
         { 0, 0, 0, 0, 2, 0},
@@ -59,7 +59,7 @@ public class PuzzleExample
         { 0, 4, 2, 0, 0, 1}
     });
     
-    public static readonly IGrid Solution6X6 = new Grid(3, 2, new[,] {
+    public static readonly IGrid Solution6X6 = Grid.Create(3, 2, new[,] {
         { 1, 2, 3, 4, 5, 6 },
         { 4, 5, 6, 1, 2, 3 },
         { 2, 1, 4, 3, 6, 5 },
@@ -71,7 +71,7 @@ public class PuzzleExample
     /// <summary>
     /// 4 x 4 puzzle, with 2 x 2 boxes
     /// </summary>
-    public static readonly IGrid Puzzle4X4 = new Grid(new [,]
+    public static readonly IGrid Puzzle4X4 = Grid.Create(new [,]
     {
         { 1, 0, 0, 0 },
         { 0, 4, 0, 2 },
@@ -79,7 +79,7 @@ public class PuzzleExample
         { 0, 0, 0, 1 }
     });
     
-    public static readonly IGrid Solution4X4 = new Grid(new [,]
+    public static readonly IGrid Solution4X4 = Grid.Create(new [,]
     {
         { 1, 2, 4, 3 },
         { 3, 4, 1, 2 },

--- a/src/Nudoku.WebApi/Program.cs
+++ b/src/Nudoku.WebApi/Program.cs
@@ -23,7 +23,7 @@ app.UseHttpsRedirection();
 
 app.MapPost("/solve", (GridDto puzzle, [FromServices] ISolver solver) =>
 {
-    var puzzleGrid = new Grid(puzzle.Size, puzzle.Cells);
+    var puzzleGrid = new Grid(puzzle.Size, puzzle.BoxWidth, puzzle.BoxHeight, puzzle.Cells);
     
     var solutionGrid = solver.FindSolution(puzzleGrid);
     


### PR DESCRIPTION
The `POST /solve` endpoint is throwing an error for non-squared grids (3x2).

This is happening due to the wrong initialisation of the Grid class that does not include the size.

To fix and prevent this from happening with static code I updated the Grid to have a single constructor that always include the required parameters. Made other util constructors static methods.